### PR TITLE
Add support for "$forceEvaluate" to bypass the gate for a single digest ...

### DIFF
--- a/scalyr.js
+++ b/scalyr.js
@@ -399,6 +399,9 @@ defineScalyrAngularModule('slyEvaluate', ['gatedScope'])
             if (isStringEmpty(alwaysEvaluateString))
               throw new Exception('Empty string is illegal for value of slyAlwaysEvaluate');
           }
+          scope.$forceEvaluate = function() {
+              scope.$$shouldBypassWatcherOnNextRun = true;
+          };
           scope.$addWatcherGate(function evaluteOnlyWhenChecker() {
             // We should only return true if expressionToCheck evaluates to a value different
             // than previousValue.
@@ -410,6 +413,10 @@ defineScalyrAngularModule('slyEvaluate', ['gatedScope'])
             }
             var result = previousValue !== currentValue;
             previousValue = currentValue;
+            if (!result && scope.$$shouldBypassWatcherOnNextRun) {
+                result = true;
+                scope.$$shouldBypassWatcherOnNextRun = false;
+            }
             return result;
           }, function shouldGateWatcher(watchExpression) {
             // Should return true if the given watcher that's about to be registered should


### PR DESCRIPTION
- As it is written, there is no way for a data binding inside a directive
  to trigger an evaluateOnlyWhen that is outside of that directive,
  because the two-way data binding won't ever get called

I'm not at all convinced that this is the best way to do this, but it's the way I found that would work.  What do you think? Any thoughts on a better way to solve the problem?

Basically I want to only update a section of the page when a given value updates, but unfortunately it's sometimes updated from within a directive which would normally use 2-way data binding.
